### PR TITLE
Bug fix

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.006805637, g: 0.008248608, b: 0.007931558, a: 1}
+  m_IndirectSpecularColor: {r: 0.011889093, g: 0.015858432, b: 0.015471702, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:

--- a/Assets/Scripts/Actions/BeyondScreenActer.cs
+++ b/Assets/Scripts/Actions/BeyondScreenActer.cs
@@ -15,9 +15,8 @@ namespace GeekSpace
             {
                 model.Pool.Push(model.Object);
             }
-            else if (model is PlayerModel)
+            else if (model is PlayerModel && Camera.main != null)
             {
-
                 float weightShip = Mathf.Round(model.Object.transform.GetChild(0).GetComponent<SpriteRenderer>().sprite.rect.width / 100) + 0.2f;
 
                 float leftBorder = Extention.GetLeftSideValueAccordingCamera(Camera.main, weightShip);
@@ -40,6 +39,7 @@ namespace GeekSpace
             else
             {
                 Debug.Log("Model Error");
+                var asd = SceneManagment.FindObjectsOfType(typeof(GameObject));
             }
 
         }

--- a/Assets/Scripts/Providers/EnemyProvider.cs
+++ b/Assets/Scripts/Providers/EnemyProvider.cs
@@ -38,7 +38,7 @@ namespace GeekSpace
         {
             _health = _enemyModel.HealthPoitns;
             _maxHealth = _health;
-            _damage = FindObjectOfType<PlayerProvider>().PlayerModel.WeaponModel.Damage;
+            _damage = FindObjectOfType<PlayerProvider>() == null ? 0.0f : FindObjectOfType<PlayerProvider>().PlayerModel.WeaponModel.Damage;
 
         }
         void OnBecameInvisible()

--- a/UserSettings/EditorUserSettings.asset
+++ b/UserSettings/EditorUserSettings.asset
@@ -9,10 +9,10 @@ EditorUserSettings:
       value: 22424703114646531740192c193746
       flags: 0
     RecentlyUsedScenePath-1:
-      value: 22424703114646680e0b0227036c6c111b07142f1f2b233e2867083debf42d
+      value: 22424703114646680e0b0227036c72111f19352f223d15332827187df7ee3d2cfb
       flags: 0
     RecentlyUsedScenePath-2:
-      value: 22424703114646680e0b0227036c72111f19352f223d15332827187df7ee3d2cfb
+      value: 22424703114646680e0b0227036c6c111b07142f1f2b233e2867083debf42d
       flags: 0
     vcSharedLogLevel:
       value: 0d5e400f0650


### PR DESCRIPTION
Замечания по проекту:

1. Не соблюдается CodeConvention - довольно сложно читать код.
2. Классы не запечатаны, доступы не везде прописаны и не везде указаны правильно. Импортированы неиспользуемые пространства имён.
3. На экране меню диссонанс. Графика а-ля пиксельная, но астероид справа вверху иной (более реальный).
4. В иерархии сцены Главного меню опечатка в группе кнопок - Busttons.
5. Регулировка уровня громкости работает очень нелогично. Бегунок громкости вносит слышимые изменения только в конце. Тут стоит применить паттерн Интерпретатор или задавать шаг бегунка вручную
6. Выпадающие списки разрешений и качества графики очень плохо читаются. Стоит тут использовать тот же шрифт, что и в остальном меню.
7. EnemyProvider. В каждом Start (который вызывается при каждом появлении врага) выполняется поиск объекта на сцене. И ищется PlayerProvider, который на сцене один (пока жив игрок). Нужно использовать паттерн внедрения зависимости, а ссылку на PlayerProvider получать на уровень выше или в фабрике.
7а. Нет проверки результата команды FindObjectOfType, сразу идёт попытка получить данные. Это вызывает баг №1.
8. После возвращения в Главное меню из игры, отображение неастроек остаётся как при старте гиры. Но при этом настройки изменены. Например, меняю уровень громкости (двигаю бегунок до середины, чтобы было тише), запускаю игру, проигрываю, возвращаюсь в Главное меню, открываю настройки и бегунок громкости находится в крайнем правом положении, хотя сама громкость снижена, как менял ранее. Аналогично по другим настройкам. Стоит обновлять отображение при открытии меню настроек в соответствии с данными.
9. В классе EnemyProvider (а также поля и соответствующие свойства в PlayerProvider, EnemyModel) поле _damage имеет тип float, а в классе WeaponModel аналогичное поле и свойство Damage имеет тип int. Нужно привести всё к одному типу.
10. В классе PlayerModel есть неиспользуемое поле _pathToPrefab.
11. В классе InputInitialisationBtns есть неиспользуемое поле _pcInputFire.
12. При постановке на паузу враги продолжают спауниться.
13. Меню паузы слишком прозрачное, если по середине экрана находится объект (например, корабль), то текст кнопок нечитабельный.
14. Не применяются настройки разрешения экрана и графики.
15. Класс Extention содержит слишком много ответственности. Стоит его разбить на более мелкие.
16. Класс BeyondScreenActer содержит Debug.
17. Класс GameInitialisationMultiplayer. Ненужные this. в конструкторе. Неиспользуемая переменная beyondScreenActer.
18. Названия классов вводят в заблуждение. Например, класс InputManager содержит только набор констант.
19. Наличие в проекте странных объектов сбивает с толку. Например, в папке Assets есть файлы MSuhinin.txt и hz.unity.

===========================================================================

Недоделки:
1. Столкновение с врагом не вызывает экран смерти
2. Экран смерти не исчезает через время

===========================================================================







Баги.
1. Класс EnemyProvider при выходе в главное меню выкидывает ошибку null-referene. Игрока уже нет, а вновь появляющиеся враги (хотя открыт экран смерти, по идее всё должно быть остановлено) пытаются получить с него данные. Вставил проверку на null.
_damage = FindObjectOfType<PlayerProvider>() == null ? 0.0f : FindObjectOfType<PlayerProvider>().PlayerModel.WeaponModel.Damage;

2. Фикс багов №1 "после нажатия рестарт ошибка", №7 "при поражении в режиме мультиплеер ошибка при возврате в главное меню", №8 "Ошибка null ref при выходе в меню, м-т расширения не может найти камеру"
Общее - null-reference при поиске камеры. Поиск камеры происходит при недозагруженной сцене. Получается, что EventsBus загружается раньше Camera.
Варианты решения (применил А):
А. Выполнять проверку камеры на null перед обращением к её компонентам
Б. Убрать GameEventSystem с GameObject-а. Он не использует функционал MonoBehaviour.
Загружать его через код тогда, когда нужен. Также убрать получение ссылок во время работы (например, использование Camera.main), получать их при старте и потом пробрасывать куда нужно.